### PR TITLE
due date support for apple reminders

### DIFF
--- a/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
+++ b/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
@@ -277,6 +277,7 @@ class ActionItemTileWidget extends StatelessWidget {
     final success = await service.addReminder(
       title: actionItem.description,
       notes: 'From Omi',
+      dueDate: actionItem.dueAt,
       listName: 'Reminders',
     );
     


### PR DESCRIPTION
### Description
Added due date support to Apple Reminders integration.

### Before and After the fix
<img width="299" height="66" alt="Screenshot 2025-10-12 at 11 06 28 PM" src="https://github.com/user-attachments/assets/a741079f-9aa4-4ff8-b679-1e0805417a9e" />

<img width="306" height="75" alt="image" src="https://github.com/user-attachments/assets/91c1c9dd-2e4d-42db-ba8c-62814bbab752" />

### Demo Code Walkthrough
https://youtu.be/ftSXgrk1AbQ
 
### Fixes #5 
